### PR TITLE
forward CFLAGS -DUSE_PORTS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ if(WITH_PORTS)
   set(HEADER_FILES ${HEADER_FILES} dispatch/PortDispatcher.hpp)
   set(DEPS ${DEPS} boost_serialization  orocos-rtt-${OROCOS_TARGET} orocos_cpp)
   add_definitions(-DUSE_PORTS)
+  set(vizkit3d_debug_drawings_PKGCONFIG_CFLAGS -DUSE_PORTS)
   
 else()
 


### PR DESCRIPTION
Actually, it would be a good idea to rename this flag to something like `VIZKIT3D_DEBUG_DRAWINGS_USE_RTT`.
Also this could be made dependent on whether RTT is found, instead of an option.