### PR TITLE
Split the commands out of the main library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,12 +5,7 @@ option(WITH_PORTS "Build with rock port support" ON)
 find_package(Eigen3 REQUIRED)
 include_directories(${EIGEN3_INCLUDE_DIR})
 
-
-set(SOURCE_FILES
-        DrawingManager.cpp
-        DeclaredChannels.cpp
-        DebugDrawing.cpp
-        DebugDrawingColors.cpp
+set(COMMANDS_SOURCE_FILES
         commands/DrawCommand.cpp
         commands/Command.cpp
         commands/RemoveDrawingCommand.cpp
@@ -27,19 +22,9 @@ set(SOURCE_FILES
         commands/primitives/DrawCylinderCommand.cpp
         commands/primitives/DrawAxesCommand.cpp
         commands/primitives/DrawAABBCommand.cpp
-        dispatch/CommandDispatcherFactory.cpp
-        dispatch/StandaloneDispatcher.cpp
-        dispatch/ExistingWidgetDispatcher.cpp
-)
+        )
 
-set(HEADER_FILES
-        DebugDrawing.hpp
-        Drawing.hpp
-        DrawingManager.hpp
-        DeclaredChannels.hpp
-        DebugDrawingColors.hpp
-        StaticDeclarationHelpers.hpp
-        PlotDataPoint.hpp
+set(COMMANDS_HEADER_FILES
         commands/DrawCommand.hpp
         commands/Command.hpp
         commands/RemoveDrawingCommand.hpp
@@ -57,6 +42,26 @@ set(HEADER_FILES
         commands/primitives/DrawAxesCommand.hpp
         commands/primitives/DrawAABBCommand.hpp
         commands/BoostSerializationExports.hpp
+        )
+
+set(SOURCE_FILES
+        DrawingManager.cpp
+        DeclaredChannels.cpp
+        DebugDrawing.cpp
+        DebugDrawingColors.cpp
+        dispatch/CommandDispatcherFactory.cpp
+        dispatch/StandaloneDispatcher.cpp
+        dispatch/ExistingWidgetDispatcher.cpp
+)
+
+set(HEADER_FILES
+        DebugDrawing.hpp
+        Drawing.hpp
+        DrawingManager.hpp
+        DeclaredChannels.hpp
+        DebugDrawingColors.hpp
+        StaticDeclarationHelpers.hpp
+        PlotDataPoint.hpp
         dispatch/ICommandDispatcher.hpp
         dispatch/CommandDispatcherFactory.hpp
         dispatch/StandaloneDispatcher.hpp
@@ -66,7 +71,6 @@ set(HEADER_FILES
 set(DEPS 
         vizkit3d
         osgViz
-        PrimitivesFactory
 )
 
 find_package(Boost REQUIRED COMPONENTS serialization system)
@@ -92,6 +96,12 @@ else()
   
 endif(WITH_PORTS)
 
+rock_library(vizkit3d_debug_drawings-commands
+    SOURCES ${COMMANDS_SOURCE_FILES}
+    HEADERS ${COMMANDS_HEADER_FILES}
+    DEPS_PKGCONFIG PrimitivesFactory
+    LIBS ${Boost_LIBRARIES}
+    )
 
 
 rock_library(vizkit3d_debug_drawings
@@ -99,8 +109,8 @@ rock_library(vizkit3d_debug_drawings
     HEADERS ${HEADER_FILES}
     DEPS_PKGCONFIG ${DEPS}
     DEPS_PLAIN ${DEPSPLAIN}
+    DEPS vizkit3d_debug_drawings-commands
 )
 
-target_link_libraries(vizkit3d_debug_drawings ${Boost_LIBRARIES})
 
 

--- a/src/DrawingManager.hpp
+++ b/src/DrawingManager.hpp
@@ -24,26 +24,26 @@ namespace vizkit3dDebugDrawings
     public:
         /** @p widget The widget that this manager should draw on */
         DrawingManager(vizkit3d::Vizkit3DWidget* widget);
-        ~DrawingManager();
+        virtual ~DrawingManager();
         
         /** Adds a drawing primitive to the @p drawingChannel.
          * If @p drawingChannel does not exist, it is created.
          * @param drawingChannel May not be empty*/
-        void addPrimitive(const std::string& drawingChannel, const osg::ref_ptr<osgviz::Object>&);
+        virtual void addPrimitive(const std::string& drawingChannel, const osg::ref_ptr<osgviz::Object>&);
         
-        void addPlotDataPoint(const std::string& plotName, const Eigen::Vector2d& dataPoint);
+        virtual void addPlotDataPoint(const std::string& plotName, const Eigen::Vector2d& dataPoint);
         
-        void clearPlot(const std::string& plotName);
+        virtual void clearPlot(const std::string& plotName);
       
         /** Removes the drawing channel.
          * I.e. unloades the vizkit3d plugin responsible for rendering this drawing
          * @note If you want to animate something, use CLEAR_DRAWING instead.*/
-        void removeDrawing(const std::string& drawingChannel);
+        virtual void removeDrawing(const std::string& drawingChannel);
         
         /** Removes the content from a drawing channel but keeps the drawing itself.
          * I.e. the vizkit3d plugin will be kept and the users settings will be retained.
          * Use this if you want to animate movements.*/
-        void clearDrawing(const std::string& drawingChannel);
+        virtual void clearDrawing(const std::string& drawingChannel);
         
         /** Remove the content from all drawings but keep the plugins.
          *  Does not clear the plots*/

--- a/src/dispatch/PortDispatcher.cpp
+++ b/src/dispatch/PortDispatcher.cpp
@@ -1,4 +1,9 @@
-#include <rtt/TaskContext.hpp> //has to be included first FIXME why?
+/* rtt/TaskContext.hpp must be included first because it uses names
+ * that will be #defined by Qt and there is no guarantee that any other
+ * #include does not and will not #include Qt headers
+ */
+#include <rtt/TaskContext.hpp>
+
 #include "PortDispatcher.hpp"
 #include <rtt/OutputPort.hpp>
 #include <iostream>

--- a/src/vizkit3d_debug_drawings-commands.pc.in
+++ b/src/vizkit3d_debug_drawings-commands.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: @TARGET_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Requires: @PKGCONFIG_REQUIRES@
+Libs: -L${libdir} -l@TARGET_NAME@ @PKGCONFIG_LIBS@
+Cflags: -I${includedir} @PKGCONFIG_CFLAGS@
+


### PR DESCRIPTION
This should not change behavior of anything, but creates the opportunity to have the orogen components transports and typekit not depend on qt.

@planthaber I think you have a working testcase for this, i am only able to check that the generated shared objects "look right". I will have a PR ready for gui/orogen/vizkit3d_debug_drawings soon; the only change there is to add "-commands" to the library name of the using_library statement of the .orogen file, changing it to the name of the new library.