### PR TITLE
Fix global empty functions

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1158,7 +1158,7 @@ INCLUDE_FILE_PATTERNS  =
 # undefined via #undef or recursively expanded use the := operator 
 # instead of the = operator.
 
-PREDEFINED             = 
+PREDEFINED             = DOXYGEN
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then 
 # this tag can be used to specify a list of macro names that should be expanded. 

--- a/src/DebugDrawing.hpp
+++ b/src/DebugDrawing.hpp
@@ -13,33 +13,36 @@
 ///////////////////////
 namespace V3DD
 {
-    void CONFIGURE_DEBUG_DRAWINGS_STANDALONE(){}
-    void CONFIGURE_DEBUG_DRAWINGS_USE_EXISTING_WIDGET(...){}
+    //These must be declared static so they do not create global symbols.
+    //Those global symbols would conflict with the symbols declared in other
+    //shared objects when ENABLE_DEBUG_DRAWINGS has been #defined there.
+    static void CONFIGURE_DEBUG_DRAWINGS_STANDALONE(){}
+    static void CONFIGURE_DEBUG_DRAWINGS_USE_EXISTING_WIDGET(...){}
 
 #ifdef USE_PORTS    
-    void CONFIGURE_DEBUG_DRAWINGS_USE_PORT(...){}
+    static void CONFIGURE_DEBUG_DRAWINGS_USE_PORT(...){}
 #endif
-    void CONFIGURE_DEBUG_DRAWINGS_USE_EXISTING_WIDGET_NO_THROW(...){}
+    static void CONFIGURE_DEBUG_DRAWINGS_USE_EXISTING_WIDGET_NO_THROW(...){}
     
     #define V3DD_DECLARE_DEBUG_DRAWING_CHANNEL(...)
     
-    void DRAW_WIREFRAME_BOX(...){}
-    void DRAW_ARROW(...){}
-    void DRAW_RING(...){}
-    void DRAW_SPHERE(...){}
-    void DRAW_CYLINDER(...){}
-    void DRAW_POLYLINE(...){}
-    void DRAW_LINE(...){}
-    void DRAW_TEXT(...){}
-    void DRAW_AXES(...){}
-    void DRAW_AABB(...){}
-    void PLOT_2D(...){}
-    void CLEAR_PLOT(...){}
-    void REMOVE_DRAWING(...){}
-    void CLEAR_DRAWING(...){}
-    void FLUSH_DRAWINGS(){}
-    void COMPLEX_DRAWING(...){}
-    std::vector<std::string> GET_DECLARED_CHANNELS(){return std::vector<std::string>();}
+    static void DRAW_WIREFRAME_BOX(...){}
+    static void DRAW_ARROW(...){}
+    static void DRAW_RING(...){}
+    static void DRAW_SPHERE(...){}
+    static void DRAW_CYLINDER(...){}
+    static void DRAW_POLYLINE(...){}
+    static void DRAW_LINE(...){}
+    static void DRAW_TEXT(...){}
+    static void DRAW_AXES(...){}
+    static void DRAW_AABB(...){}
+    static void PLOT_2D(...){}
+    static void CLEAR_PLOT(...){}
+    static void REMOVE_DRAWING(...){}
+    static void CLEAR_DRAWING(...){}
+    static void FLUSH_DRAWINGS(){}
+    static void COMPLEX_DRAWING(...){}
+    static std::vector<std::string> GET_DECLARED_CHANNELS(){return std::vector<std::string>();}
 }
 #else
  

--- a/src/DebugDrawing.hpp
+++ b/src/DebugDrawing.hpp
@@ -3,7 +3,7 @@
 /**This is the main header that should be included to use debug drawings.
  * It defines all required macros */
 
-#ifndef ENABLE_DEBUG_DRAWINGS
+#if !defined(ENABLE_DEBUG_DRAWINGS) && !defined(DOXYGEN)
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This should fix the issue where having different settings of ENABLE_DEBUG_DRAWINGS in the same binary(rock-display) causes the same effect as if ENABLE_DEBUG_DRAWINGS were off everywhere. This has been compile tested, please test if this fixes the problem.