### PR TITLE
Fix V3DD-commands not having -DUSE_PORTS in its .pc file

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -77,6 +77,15 @@ Every component that contains drawing code needs to link against *libvizkit3d_de
 DEPS_PKGCONFIG
     vizkit3d_debug_drawings
 ```
+If the component only needs to work with the command submission side and
+wants to avoid actually linking against Qt libraries, they can link against
+*libvizkit3d_debug_drawings-commands* instead. (This is generally the case
+for rock orogen components.)
+```
+DEPS_PKGCONFIG
+    vizkit3d_debug_drawings-commands
+```
+
 By default all drawing code is disabled and will be removed by the compiler.
 To enable it *ENABLE_DEBUG_DRAWINGS* needs to be defined for every component
 containing debug drawing commands.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ if(WITH_PORTS)
   set(DEPS ${DEPS} orocos-rtt-${OROCOS_TARGET})
    
   add_definitions(-DUSE_PORTS)
+  set(vizkit3d_debug_drawings-commands_PKGCONFIG_CFLAGS -DUSE_PORTS)
   set(vizkit3d_debug_drawings_PKGCONFIG_CFLAGS -DUSE_PORTS)
   
 else()


### PR DESCRIPTION
Also updates the README to mention -commands.