### PR TITLE
Add another library that only implements the bits needed for rock ports

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -77,13 +77,21 @@ Every component that contains drawing code needs to link against *libvizkit3d_de
 DEPS_PKGCONFIG
     vizkit3d_debug_drawings
 ```
-If the component only needs to work with the command submission side and
+If the component only needs to work with the command creation side and
 wants to avoid actually linking against Qt libraries, they can link against
 *libvizkit3d_debug_drawings-commands* instead. (This is generally the case
-for rock orogen components.)
+for libraries.)
 ```
 DEPS_PKGCONFIG
     vizkit3d_debug_drawings-commands
+```
+If the component additionally wants to pass commands through rock ports
+but wants to avoid linking against Qt libraries, they can link against
+*libvizkit3d_debug_drawings-ports* instead. (This is generally the case
+for rock orogen components.)
+```
+DEPS_PKGCONFIG
+    vizkit3d_debug_drawings-ports
 ```
 
 By default all drawing code is disabled and will be removed by the compiler.
@@ -114,13 +122,16 @@ The `PORT` configuration should be configured exactly once per task (although it
 ==== STANDALONE Configuration
 In standalone mode a new QThread will be started containing a new QApplication context.
 This thread is used to display a Vizkit3DWidget which is used for visualization.
+This requires using the fully featured vizkit3d_debug_drawings library somewhere in the final application.
 
 ==== EXISTING_WIDGET Configuration
 In this mode the application expects that there already is a QApplication context
 and a Vizkit3DWidget already exists. The existing widget will be used for visualization.
+This requires using the fully featured vizkit3d_debug_drawings library somewhere in the final application.
 
 ==== PORT Configuration
 In port mode the application expects to be running inside a rock task. The context of that task has to be provided. For each drawing channel a new port will be added to the task and the corresponding drawing commands will be sent through that port. The drawings can be visualized using rock-display. Additional configuration is needed for this to work. See example below.
+This requires using the vizkit3d_debug_drawings-ports library in the task.
 
 
 === Declaring Drawings

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,7 +87,8 @@ if(WITH_PORTS)
   add_definitions(-DUSE_PORTS)
   set(vizkit3d_debug_drawings-commands_PKGCONFIG_CFLAGS -DUSE_PORTS)
   set(vizkit3d_debug_drawings_PKGCONFIG_CFLAGS -DUSE_PORTS)
-  
+  set(vizkit3d_debug_drawings-ports_PKGCONFIG_CFLAGS -DUSE_PORTS)
+
 else()
 
   message("Building without port support")
@@ -109,5 +110,23 @@ rock_library(vizkit3d_debug_drawings
     DEPS vizkit3d_debug_drawings-commands Boost::serialization Boost::system
 )
 
+if(WITH_PORTS)
+    rock_library(vizkit3d_debug_drawings-ports
+        SOURCES
+        DebugDrawing.cpp
+        DeclaredChannels.cpp
+        dispatch/CommandDispatcherFactory.cpp
+        dispatch/PortDispatcher.cpp
 
+        HEADERS
+        DebugDrawing.hpp
+        DeclaredChannels.hpp
+        dispatch/CommandDispatcherFactory.hpp
+        dispatch/ICommandDispatcher.hpp
+        dispatch/PortDispatcher.hpp
 
+        DEPS vizkit3d_debug_drawings-commands Boost::serialization Boost::system
+    )
+
+    target_compile_definitions(vizkit3d_debug_drawings-ports PRIVATE DISABLE_QT_BUILD)
+endif()

--- a/src/DebugDrawing.cpp
+++ b/src/DebugDrawing.cpp
@@ -210,6 +210,7 @@ void FLUSH_DRAWINGS()
     CommandDispatcherFactory::getInstance()->flush(); 
 }
 
+#ifndef DISABLE_QT_BUILD
 void CONFIGURE_DEBUG_DRAWINGS_STANDALONE()
 {
     CommandDispatcherFactory::createStandaloneDispatcher();
@@ -218,8 +219,8 @@ void CONFIGURE_DEBUG_DRAWINGS_STANDALONE()
 void CONFIGURE_DEBUG_DRAWINGS_USE_EXISTING_WIDGET(vizkit3d::Vizkit3DWidget * widget)
 {
     CommandDispatcherFactory::createWidgetDispatcher(widget);
-
 }
+#endif
 
 std::vector<std::string> GET_DECLARED_CHANNELS()
 {

--- a/src/dispatch/CommandDispatcherFactory.cpp
+++ b/src/dispatch/CommandDispatcherFactory.cpp
@@ -1,6 +1,8 @@
 #include "CommandDispatcherFactory.hpp"
+#ifndef DISABLE_QT_BUILD
 #include "StandaloneDispatcher.hpp"
 #include "ExistingWidgetDispatcher.hpp"
+#endif
 
 #ifdef USE_PORTS
   #include "PortDispatcher.hpp"
@@ -36,6 +38,7 @@ void CommandDispatcherFactory::createPortDispatcher(RTT::TaskContext* taskContex
 }
 #endif
 
+#ifndef DISABLE_QT_BUILD
 void CommandDispatcherFactory::createStandaloneDispatcher()
 {
     std::lock_guard<std::mutex> lock(createMutex);
@@ -62,6 +65,7 @@ void CommandDispatcherFactory::createWidgetDispatcher(vizkit3d::Vizkit3DWidget* 
         std::cout << "WARNING: CommandDispatcherFactory::createWidgetDispatcher() called multiple times" << std::endl;
     }
 }
+#endif
 
 std::shared_ptr<ICommandDispatcher> CommandDispatcherFactory::getInstance()
 {

--- a/src/vizkit3d_debug_drawings-ports.pc.in
+++ b/src/vizkit3d_debug_drawings-ports.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: @TARGET_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Requires: @PKGCONFIG_REQUIRES@
+Libs: -L${libdir} -l@TARGET_NAME@ @PKGCONFIG_LIBS@
+Cflags: -I${includedir} @PKGCONFIG_CFLAGS@
+


### PR DESCRIPTION
This is to allow rock tasks to actually provide the command creation and submission infrastructure for use with ports, without also pulling in vizkit3d and its qt dependency.

This has been tested to compile with a rock task with ENABLE_DEBUG_DRAWINGS active. Since there are no code _changes_ relative to the full library(only removal of whole functions), i assume that this still works for tasks only using the rock ports mechanism. Otherwise, missing functions would have been found during linking the default deployments.